### PR TITLE
Remove np.unicode_

### DIFF
--- a/pdstable/__init__.py
+++ b/pdstable/__init__.py
@@ -69,7 +69,7 @@ else:
     ENCODING = {}
 
 # This is an exhaustive tuple of string-like types
-STRING_TYPES = (str, bytes, bytearray, np.str_, np.bytes_, np.unicode_)
+STRING_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
 
 # Needed because the default value of strip is False
 def tai_from_iso(string):


### PR DESCRIPTION
`np.unicode_` has been removed in NumPy 2.0 and only `np.str_` is valid now. Removed `np.unicode_` from the list of possible string types.
