### PR TITLE
Repairs for pdsparser 1.0, which uses a dictionary instead of an internal tree of 'nodes'

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
       fail-fast: false
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "rms-pdstable"
 dynamic = ["version"]
 description = "Routines for reading PDS3 tables"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
   "rms-julian",
   "rms-pdsparser",
@@ -25,7 +25,6 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: Utilities",
   "License :: OSI Approved :: Apache Software License",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Sorry this was necessary. I see that pdstable.py dates back to 2011 so...

pdsparser has been rewritten so that it uses a simple dictionary rather than an internal tree of "PdsNode" objects. In the other applications I was aware of, the first thing you do with a PdsLabel object is call `as_dict()`, which converts it to a dictionary. In this very old code, it was actually using the nodes directly, so that it why it was broken. It needed a smattering of fixes to make it dictionary-friendly, but now unit tests pass.