### PR TITLE
Fix INTERCHANGE_FORMAT bug

### DIFF
--- a/pdstable/__init__.py
+++ b/pdstable/__init__.py
@@ -1035,7 +1035,9 @@ class PdsTableInfo(object):
         table_dict = self.label[key[1:]]
 
         # Save key info about the table
-        if table_dict["INTERCHANGE_FORMAT"] != "ASCII":
+        interchange_format = (table_dict.get("INTERCHANGE_FORMAT", '')
+                              or table_dict["INTERCHANGE_FORMAT_1"])
+        if interchange_format != "ASCII":
             raise IOError('PDS table is not in ASCII format')
 
         self.rows = table_dict["ROWS"]


### PR DESCRIPTION
This issue just came up in the `rms-pdsfile` unit tests. It's very obscure.

As a good citizen, I changed the behavior of pdsparser to match the behavior we discussed at the last group meeting regarding multiple occurrences of the same attribute in a label. Previously, it would add a suffix "_2", "_3" etc. to later occurrences but would leave the first occurrence unchanged. I changed it so that it would instead add a "_1" suffix to the first. BTW, there is an option in the Pds3Label constructor to revert to the previous behavior; set `first_suffix=False`.

The failing unit test is for the file `HSTU0_5167_index.lbl`. As a good PDS3 table, is has an attribute `INTERCHANGE_FORMAT = ASCII`, as is required by the pdstable module. However, it also has a _column_ named "INTERCHANGE_FORMAT". Because the returned dictionary converts column names to additional attributes, it therefore now has two keys with this value. After the change, the first key becomes "INTERCHANGE_FORMAT_1", so suddenly the line:
```
        if table_dict["INTERCHANGE_FORMAT"] != "ASCII":
```
raises a KeyError. Surprise!

I could have fixed this by using the `first_suffix=False` option, but I think we really want those "_1" suffixes under most circumstances. My solution is a bit more convoluted, checking for the key with a "_1" suffix if the expected key is not found.

With this change to pdstable, the pdsfile unit tests should work again.