### PR TITLE
Fix crash when PdsTable is given an FCPath

### DIFF
--- a/pdstable/__init__.py
+++ b/pdstable/__init__.py
@@ -49,8 +49,8 @@ class PdsTable:
         """Constructor for a PdsTable object.
 
         Parameters:
-            label_file (str): The path to the PDS label of the table file. Must be
-                supplied to get proper relative path resolution.
+            label_file (str or Path or FCPath): The path to the PDS label of the table
+                file. Must be supplied to get proper relative path resolution.
             label_contents (list or Pds3Label, optional): The contents of the label as a
                 list of strings if we shouldn't read it from the file. Alternatively, a
                 Pds3Label object to avoid label parsing entirely. Note: this param is for

--- a/pdstable/utils.py
+++ b/pdstable/utils.py
@@ -17,12 +17,13 @@ def is_pds4_label(label_name):
     """Check if the given label is a PDS4 label.
 
     Parameters:
-        label_name (str): The name of the label file to check.
+        label_name (str or Path or FCPath): The name of the label file to check.
 
     Returns:
         bool: True if the label is a PDS4 label, False otherwise.
     """
 
+    label_name = str(label_name)
     for ext in _PDS4_LBL_EXTENSIONS:
         if label_name.endswith(ext):
             return True


### PR DESCRIPTION
When the PdsTable constructor is given something other than a string (e.g. a Path or FCPath) it crashes. This is a simple fix to correct that.
