### PR TITLE
Revert changes that broke pdsindexshelf

### DIFF
--- a/pdstable/__init__.py
+++ b/pdstable/__init__.py
@@ -1253,11 +1253,12 @@ class PdsTable:
         dicts_by_row = self.dicts_by_row()
         return dicts_by_row[k]
 
-    def _create_index_rows_by_filename_key(self):
+    def index_rows_by_filename_key(self):
         """Create a dictionary of row indices keyed by the file basename associated
         with the row.
 
         The key has the file extension stripped away and is converted to lower case.
+        The result is available in the filename_keys attribute.
         """
 
         if self._rows_by_filename is not None:
@@ -1286,6 +1287,19 @@ class PdsTable:
         self._rows_by_filename = rows_by_filename
         self._filename_keys = filename_keys
 
+    @property
+    def filename_keys(self):
+        """The list of filename keys for the table.
+
+        Returns:
+            list: A list of filename keys.
+        """
+
+        if self._filename_keys is None:
+            self.index_rows_by_filename_key()
+
+        return self._filename_keys
+
     def row_indices_by_filename_key(self, key):
         """Quick lookup of the row indices associated with a filename key.
 
@@ -1297,7 +1311,7 @@ class PdsTable:
         """
 
         # Create the index if necessary
-        self._create_index_rows_by_filename_key()
+        self.index_rows_by_filename_key()
 
         return self._rows_by_filename[key.lower()]
 
@@ -1313,7 +1327,7 @@ class PdsTable:
         """
 
         # Create the index if necessary
-        self._create_index_rows_by_filename_key()
+        self.index_rows_by_filename_key()
 
         indices = self._rows_by_filename[key.lower()]
 


### PR DESCRIPTION
During the recent rewrite the `index_rows_by_filename_key` method was made internal along with the associated `filename_keys` attribute. However, it turns out these are used by `pdsindexshelf`. I have restore their original functionality (with some improvements).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a public API to access filename-based keys, with automatic (lazy) index creation when accessed.
  - Exposed a public way to retrieve rows by filename key using the on-demand index.

- Refactor
  - Promoted internal indexing logic to a public, on-demand API for clearer, consistent usage.
  - Updated internal call sites to use the new public interface without changing existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request reverts changes from a recent rewrite that broke the functionality relied upon by pdsindexshelf. The modifications include renaming an internal method to make it publicly accessible and adding a property for 'filename_keys', thus restoring the expected behavior. Enhanced inline documentation and updated method calls further clarify the changes. Overall, the PR ensures backward compatibility while incorporating useful improvements.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>